### PR TITLE
Introduce the global instance pattern

### DIFF
--- a/lib/strings/inflection.rb
+++ b/lib/strings/inflection.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
-require_relative "inflection/combined_noun"
-require_relative "inflection/configuration"
-require_relative "inflection/noun"
-require_relative "inflection/parser"
-require_relative "inflection/verb"
+require "forwardable"
+
+require_relative "inflection/inflector"
 require_relative "inflection/version"
 
 module Strings
@@ -11,192 +9,14 @@ module Strings
     # Error raised by this inflector
     class Error < StandardError; end
 
-    # Create a noun object
-    #
-    # @api public
-    def Noun(word)
-      Noun[word]
-    end
-    module_function :Noun
+    class << self
+      extend Forwardable
 
-    # Create a verb object
-    #
-    # @api public
-    def Verb(word)
-      Verb[word]
-    end
-    module_function :Verb
+      def_delegators :global, *(Inflection::Inflector.instance_methods - Inflection.methods)
 
-    # A configuration object
-    #
-    # @api public
-    def configuration
-      @configuration ||= Configuration.new
-    end
-    module_function :configuration
-
-    # Reset configuration and remove loaded inflections
-    #
-    # @api public
-    def reset(scope = :all)
-      configuration.reset(scope)
-    end
-    module_function :reset
-
-    # Configure custom inflections
-    #
-    # @example
-    #   configure do |config|
-    #     config.plural "index", "indexes"
-    #     config.singular "axes", "ax"
-    #   end
-    #
-    # @api public
-    def configure
-      if block_given?
-        yield configuration
-      else
-        configuration
+      def global
+        @global ||= Inflector.new
       end
     end
-    module_function :configure
-
-    # Check if word is uncountable
-    #
-    # @param [String] word
-    #   the word to check
-    #
-    # @return [Boolean]
-    #
-    # @api private
-    def uncountable?(word)
-      Noun[word].uncountable?
-    end
-    module_function :uncountable?
-
-    # Inflect a noun into a correct form
-    #
-    # @example
-    #   Strings::Inflection.inflect("error", 3)
-    #   # => "errors"
-    #
-    # @param [String] word
-    #   the word to inflect
-    # @param [Integer] count
-    #   the count of items
-    #
-    # @api public
-    def inflect(word, count, term: :noun)
-      template = !!(word =~ /\{\{([^\}]+)\}\}/)
-
-      Parser.parse(template ? word : "{{#{term.upcase[0]}:#{word}}}", count)
-    end
-    module_function :inflect
-
-    # Inflect a pural word to its singular form
-    #
-    # @example
-    #   Strings::Inflection.singularize("errors")
-    #   # => "error"
-    #
-    # @param [String] word
-    #   the noun to inflect to singular form
-    #
-    # @api public
-    def singularize(word, term: :noun)
-      case term
-      when :noun, :n
-        Noun[word].singular
-      when :verb, :v
-        Verb[word].singular
-      end
-    end
-    module_function :singularize
-
-    # Inflect a word to its plural form
-    #
-    # @example
-    #   Strings::Inflection.pluralize("error")
-    #   # => "errors"
-    #
-    # @param [String] word
-    #   noun to inflect to plural form
-    #
-    # @api public
-    def pluralize(word, term: :noun)
-      case term
-      when :noun, :n
-        Noun[word].plural
-      when :verb, :v
-        Verb[word].plural
-      end
-    end
-    module_function :pluralize
-
-    # Check if noun is in singular form
-    #
-    # @example
-    #   Strings::Inflection.singular?("error")
-    #   # => true
-    #
-    # @return [Boolean]
-    #
-    # @api public
-    def singular?(word, term: :noun)
-      case term.to_sym
-      when :noun, :n
-        Noun[word].singular?
-      when :verb, :v
-        Verb[word].singular?
-      else
-        raise Error, "Unknown option '#{term}' as a term"
-      end
-    end
-    module_function :singular?
-
-    # Check if noun is in plural form
-    #
-    # @example
-    #   Strings::Inflection.plural?("errors")
-    #   # => true
-    #
-    # @return [Boolean]
-    #
-    # @api public
-    def plural?(word, term: :noun)
-      case term.to_sym
-      when :noun, :n
-        Noun[word].plural?
-      when :verb, :v
-        Verb[word].plural?
-      else
-        raise Error, "Unknown option '#{term}' as a term"
-      end
-    end
-    module_function :plural?
-
-
-    # Join a list of words into a single sentence
-    #
-    # @example
-    #   Strings::Inflection.join_words("one", "two", "three")
-    #   # => "one, two and three"
-    #
-    # @param [Array[String]] words
-    #   the words to join
-    # @param [String] separator
-    #   the character to use to join words, defaults to `,`
-    # @param [String] final_separator
-    #   the separator used before joining the last word
-    # @param [String] conjunctive
-    #   the word used for combining the last word with the rest
-    #
-    # @return [String]
-    #
-    # @api public
-    def join_words(*words, **options)
-      CombinedNoun.new(words).join_words(**options)
-    end
-    module_function :join_words
   end # Inflection
 end # Strings

--- a/lib/strings/inflection/inflector.rb
+++ b/lib/strings/inflection/inflector.rb
@@ -23,15 +23,13 @@ module Strings
       #
       # @api public
       def Noun(word)
-        # TODO: Probably use an internal registry.
-        Noun[word]
+        Noun.new(word, inflector: self)
       end
 
       # Create a verb object
       #
       # @api public
       def Verb(word)
-        # TODO: Probably use an internal registry.
         Verb[word]
       end
 
@@ -68,8 +66,7 @@ module Strings
       #
       # @api private
       def uncountable?(word)
-        # TODO: Probably look up in the current registry.
-        Noun[word].uncountable?
+        Noun(word).uncountable?
       end
 
       # Inflect a noun into a correct form
@@ -103,11 +100,9 @@ module Strings
       def singularize(word, term: :noun)
         case term
         when :noun, :n
-          # TODO: Probably lookup in the current registry.
-          Noun[word].singular
+          Noun(word).singular
         when :verb, :v
-          # TODO: Probably lookup in the current registry.
-          Verb[word].singular
+          Verb(word).singular
         end
       end
 
@@ -124,11 +119,9 @@ module Strings
       def pluralize(word, term: :noun)
         case term
         when :noun, :n
-          # TODO: Probably lookup in the current registry.
-          Noun[word].plural
+          Noun(word).plural
         when :verb, :v
-          # TODO: Probably lookup in the current registry.
-          Verb[word].plural
+          Verb(word).plural
         end
       end
 
@@ -144,11 +137,9 @@ module Strings
       def singular?(word, term: :noun)
         case term.to_sym
         when :noun, :n
-          # TODO: Probably lookup in the current registry.
-          Noun[word].singular?
+          Noun(word).singular?
         when :verb, :v
-          # TODO: Probably lookup in the current registry.
-          Verb[word].singular?
+          Verb(word).singular?
         else
           raise Error, "Unknown option '#{term}' as a term"
         end
@@ -166,11 +157,9 @@ module Strings
       def plural?(word, term: :noun)
         case term.to_sym
         when :noun, :n
-          # TODO: Probably lookup in the current registry.
-          Noun[word].plural?
+          Noun(word).plural?
         when :verb, :v
-          # TODO: Probably lookup in the current registry.
-          Verb[word].plural?
+          Verb(word).plural?
         else
           raise Error, "Unknown option '#{term}' as a term"
         end

--- a/lib/strings/inflection/inflector.rb
+++ b/lib/strings/inflection/inflector.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+require_relative "combined_noun"
+require_relative "configuration"
+require_relative "noun"
+require_relative "parser"
+require_relative "verb"
+
+module Strings
+  module Inflection
+    # An inflector with its own configuration.
+    #
+    class Inflector
+      # The configuration object
+      #
+      # @api public
+      attr_reader :configuration
+
+      def initialize
+        @configuration = Configuration.new
+      end
+
+      # Create a noun object
+      #
+      # @api public
+      def Noun(word)
+        # TODO: Probably use an internal registry.
+        Noun[word]
+      end
+
+      # Create a verb object
+      #
+      # @api public
+      def Verb(word)
+        # TODO: Probably use an internal registry.
+        Verb[word]
+      end
+
+      # Reset configuration and remove loaded inflections
+      #
+      # @api public
+      def reset(scope = :all)
+        configuration.reset(scope)
+      end
+
+      # Configure custom inflections
+      #
+      # @example
+      #   configure do |config|
+      #     config.plural "index", "indexes"
+      #     config.singular "axes", "ax"
+      #   end
+      #
+      # @api public
+      def configure
+        if block_given?
+          yield configuration
+        else
+          configuration
+        end
+      end
+
+      # Check if word is uncountable
+      #
+      # @param [String] word
+      #   the word to check
+      #
+      # @return [Boolean]
+      #
+      # @api private
+      def uncountable?(word)
+        # TODO: Probably look up in the current registry.
+        Noun[word].uncountable?
+      end
+
+      # Inflect a noun into a correct form
+      #
+      # @example
+      #   Strings::Inflection.inflect("error", 3)
+      #   # => "errors"
+      #
+      # @param [String] word
+      #   the word to inflect
+      # @param [Integer] count
+      #   the count of items
+      #
+      # @api public
+      def inflect(word, count, term: :noun)
+        template = !!(word =~ /\{\{([^\}]+)\}\}/)
+
+        Parser.parse(template ? word : "{{#{term.upcase[0]}:#{word}}}", count)
+      end
+
+      # Inflect a pural word to its singular form
+      #
+      # @example
+      #   Strings::Inflection.singularize("errors")
+      #   # => "error"
+      #
+      # @param [String] word
+      #   the noun to inflect to singular form
+      #
+      # @api public
+      def singularize(word, term: :noun)
+        case term
+        when :noun, :n
+          # TODO: Probably lookup in the current registry.
+          Noun[word].singular
+        when :verb, :v
+          # TODO: Probably lookup in the current registry.
+          Verb[word].singular
+        end
+      end
+
+      # Inflect a word to its plural form
+      #
+      # @example
+      #   Strings::Inflection.pluralize("error")
+      #   # => "errors"
+      #
+      # @param [String] word
+      #   noun to inflect to plural form
+      #
+      # @api public
+      def pluralize(word, term: :noun)
+        case term
+        when :noun, :n
+          # TODO: Probably lookup in the current registry.
+          Noun[word].plural
+        when :verb, :v
+          # TODO: Probably lookup in the current registry.
+          Verb[word].plural
+        end
+      end
+
+      # Check if noun is in singular form
+      #
+      # @example
+      #   Strings::Inflection.singular?("error")
+      #   # => true
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      def singular?(word, term: :noun)
+        case term.to_sym
+        when :noun, :n
+          # TODO: Probably lookup in the current registry.
+          Noun[word].singular?
+        when :verb, :v
+          # TODO: Probably lookup in the current registry.
+          Verb[word].singular?
+        else
+          raise Error, "Unknown option '#{term}' as a term"
+        end
+      end
+
+      # Check if noun is in plural form
+      #
+      # @example
+      #   Strings::Inflection.plural?("errors")
+      #   # => true
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      def plural?(word, term: :noun)
+        case term.to_sym
+        when :noun, :n
+          # TODO: Probably lookup in the current registry.
+          Noun[word].plural?
+        when :verb, :v
+          # TODO: Probably lookup in the current registry.
+          Verb[word].plural?
+        else
+          raise Error, "Unknown option '#{term}' as a term"
+        end
+      end
+
+      # Join a list of words into a single sentence
+      #
+      # @example
+      #   Strings::Inflection.join_words("one", "two", "three")
+      #   # => "one, two and three"
+      #
+      # @param [Array[String]] words
+      #   the words to join
+      # @param [String] separator
+      #   the character to use to join words, defaults to `,`
+      # @param [String] final_separator
+      #   the separator used before joining the last word
+      # @param [String] conjunctive
+      #   the word used for combining the last word with the rest
+      #
+      # @return [String]
+      #
+      # @api public
+      def join_words(*words, **options)
+        CombinedNoun.new(words).join_words(**options)
+      end
+    end # Inflector
+  end # Inflection
+end # Strings

--- a/lib/strings/inflection/noun.rb
+++ b/lib/strings/inflection/noun.rb
@@ -7,6 +7,14 @@ require_relative "nouns"
 module Strings
   module Inflection
     class Noun < Term
+      attr_reader :inflector
+
+      def initialize(word, inflector: Inflection.global)
+        @inflector = inflector
+
+        super(word)
+      end
+
       # Check if word is uncountable
       #
       # @param [String] word
@@ -16,7 +24,7 @@ module Strings
       #
       # @api private
       def uncountable?
-        Inflection.configuration.uncountables[:noun].include?(word.downcase) ||
+        inflector.configuration.uncountables[:noun].include?(word.downcase) ||
           Nouns.uncountable.include?(word.downcase)
       end
 
@@ -33,7 +41,7 @@ module Strings
       def singular
         return word if word.to_s.empty?
 
-        find_match(Inflection.configuration.singulars[:noun]) ||
+        find_match(inflector.configuration.singulars[:noun]) ||
           (uncountable? && word) || find_match(Nouns.singulars) || word
       end
 
@@ -50,7 +58,7 @@ module Strings
       def plural
         return word if word.to_s.empty?
 
-        find_match(Inflection.configuration.plurals[:noun]) ||
+        find_match(inflector.configuration.plurals[:noun]) ||
           (uncountable? && word) || find_match(Nouns.plurals) || word
       end
 

--- a/spec/unit/inflector_spec.rb
+++ b/spec/unit/inflector_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe Strings::Inflection::Inflector do
+  before do
+    instance_1.configure do |config|
+      config.plural "index", "indexes"
+    end
+  end
+
+  let(:instance_1) {
+    described_class.new
+  }
+
+  let(:instance_2) {
+    described_class.new
+  }
+
+  it "isolates its configuration from other instances" do
+    expect(instance_1.pluralize("index")).to eq("indexes")
+    expect(instance_2.pluralize("index")).to eq("indices")
+  end
+
+  it "isolates its configuration from the global instance" do
+    expect(Strings::Inflection.pluralize("index")).to eq("indices")
+  end
+end


### PR DESCRIPTION
### Describe the change
Introduces the global instance pattern, discussed a few weeks ago in [this thread](https://twitter.com/piotr_murach/status/1202013770723287040) and prototyped in [this gist](https://gist.github.com/bryanp/10d08dcc810b10c66881e4ab10154d03). Multiple `Strings::Inflection::Inflector` instances can be defined, each with their own isolated configuration. `Strings::Inflection` delegates to an internal global instance.

### Why are we doing this?
This change continues to support the current api, which is arguably more convenient for most needs. But it does this within an architecture that's flexible for more complex use-cases.

### Benefits
It makes it possible to have multiple inflectors with different configurations.

### Drawbacks
The global instance architecture is more complex, particularly for gem maintainers.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[] Documentation updated?
