### PR TITLE
Fix extensions require path

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ using MyStringExt
 However, if you want to include all the **Strings::Inflection** methods, you can use provided extensions file:
 
 ```ruby
-require "strings/inflect/extensions"
+require "strings/inflection/extensions"
 
 using Strings::Inflection::Extensions
 ```


### PR DESCRIPTION
Fixed the `require` path for the extensions:

```diff
-require "strings/inflect/extensions"
+require "strings/inflection/extensions"
```
